### PR TITLE
Closes #24, Add centered camera on player

### DIFF
--- a/Live/Classes/AppDelegate.cpp
+++ b/Live/Classes/AppDelegate.cpp
@@ -21,7 +21,8 @@ using namespace CocosDenshion;
 
 USING_NS_CC;
 
-static cocos2d::Size designResolutionSize = cocos2d::Size(1024, 768);
+static cocos2d::Size designResolutionSize = cocos2d::Size(WINDOW_WIDTH,
+        WINDOW_HEIGHT);
 static cocos2d::Size smallResolutionSize = cocos2d::Size(480, 320);
 static cocos2d::Size mediumResolutionSize = cocos2d::Size(1024, 768);
 static cocos2d::Size largeResolutionSize = cocos2d::Size(2048, 1536);

--- a/Live/Classes/MainScene.cpp
+++ b/Live/Classes/MainScene.cpp
@@ -18,18 +18,21 @@ Scene* MainScene::createScene() {
 
 // on "init" you need to initialize your instance
 bool MainScene::init() {
+    m_game_layer = Layer::create();
     m_map_manager = new MapManager();
 
     m_player = new Player("Animation/boy_walk_down.plist",SPRITE_INDEX);
 
     // Instantiate HUD and add to scene
     m_hud = new HUD(m_player);
-    this->addChild(m_map_manager->getTileMap(), -1);
+    m_game_layer->addChild(m_map_manager->getTileMap(), -1);
+    // add HUD to the root layer
     this->addChild(m_hud, 2);
+    this->addChild(m_game_layer,0);
 
-    m_map_manager->getTileMap()->addChild(m_player->getSprite(),
+    m_game_layer->addChild(m_player->getSprite(),
                                           INT_MAX);  // Player always on top
-    m_player->setPosition(Point(100, 100));
+    m_player->setPosition(Point(WINDOW_WIDTH/2, WINDOW_HEIGHT/2));
 
     m_map_items.push_back(new Food());
     m_map_items.push_back(new Food());
@@ -57,6 +60,11 @@ bool MainScene::init() {
 
     // Let cocos know we have an update function to be called.
     this->scheduleUpdate();
+
+    // Setup camera to follow the player
+    m_camera = Follow::create(m_player->getSprite(),Rect::ZERO);
+    m_camera->retain();
+    m_game_layer->runAction(m_camera);
 
     return true;
 }

--- a/Live/Classes/MainScene.h
+++ b/Live/Classes/MainScene.h
@@ -9,6 +9,9 @@
 #include "cocos2d.h"
 #include "MapManager.h"
 
+#define WINDOW_WIDTH 1024
+#define WINDOW_HEIGHT 768
+
 class MainScene : public cocos2d::Scene {
 public:
     static cocos2d::Scene* createScene();
@@ -32,6 +35,8 @@ private:
     bool m_key_c_released = true;
     // used to track gameover state, currently used to reject keyboard input
     bool m_game_over = false;
+    cocos2d::Follow* m_camera;
+    cocos2d::Layer* m_game_layer;
 };
 
 #endif  // __MAIN_SCENE_H__

--- a/Live/Classes/Player.h
+++ b/Live/Classes/Player.h
@@ -9,7 +9,7 @@
 
 #define START_X     100
 #define START_Y     100
-#define ANIM_SEC    0.3f
+#define ANIM_SEC    0.2f
 #define STATIONARY_INDEX 1  // Refers to where in the sprite frames the stationary
                             // sprite is
 #define FRAME_COUNT 3


### PR DESCRIPTION
Also made a small change to the animation delta, to make it look nicer. Added a game layer in main scene, that holds all game components except the HUD. The new camera is attached to the game layer, so the main camera still draws the statically placed HUD.