### PR TITLE
Implemented a resource layer, allow players to walk behind obstacles

### DIFF
--- a/Live/Classes/Direction.h
+++ b/Live/Classes/Direction.h
@@ -1,0 +1,11 @@
+#pragma once
+
+// Define all the different directions
+typedef enum {
+    DIR_DOWN,
+    DIR_LEFT,
+    DIR_RIGHT,
+    DIR_UP,
+
+    NUM_DIR
+} Direction;

--- a/Live/Classes/GameObject.cpp
+++ b/Live/Classes/GameObject.cpp
@@ -14,11 +14,22 @@ void GameObject::setPosition(Vec2 pos) { m_sprite->setPosition(pos); }
 
 Vec2 GameObject::getPosition() const { return m_sprite->getPosition(); }
 
+void GameObject::setZOrder(float z) {
+    m_sprite->setZOrder(z);
+}
+
 Sprite* GameObject::newSprite() {
     m_sprite = Sprite::create(m_sprite_file,
                               Rect(m_grid_pos_x * SPRITE_DIM, m_grid_pos_y * SPRITE_DIM,
                                    SPRITE_DIM, SPRITE_DIM));
     m_sprite->setScale(2.0);
+    return m_sprite;
+}
+
+Sprite* GameObject::newSprite(int width, int length) {
+    m_sprite = Sprite::create(m_sprite_file,
+                              Rect(m_grid_pos_x, m_grid_pos_y,
+                                   width, length));
     return m_sprite;
 }
 

--- a/Live/Classes/GameObject.h
+++ b/Live/Classes/GameObject.h
@@ -12,9 +12,11 @@ public:
     virtual ~GameObject();
     virtual void setPosition(float x, float y);
     virtual void setPosition(cocos2d::Vec2);
+    virtual void setZOrder(float z);
     virtual cocos2d::Vec2 getPosition() const;
     const float distanceFrom(const GameObject& other);
     virtual cocos2d::Sprite* newSprite();
+    virtual cocos2d::Sprite* newSprite(int width, int length);
     virtual cocos2d::Sprite* getSprite();
 
 protected:

--- a/Live/Classes/MainScene.cpp
+++ b/Live/Classes/MainScene.cpp
@@ -1,6 +1,8 @@
 #include "Food.h"
 #include "MainScene.h"
 #include "SimpleAudioEngine.h"
+#include "Direction.h"
+#include "ResourceLayer.h"
 
 USING_NS_CC;
 
@@ -30,8 +32,7 @@ bool MainScene::init() {
     this->addChild(m_hud, 2);
     this->addChild(m_game_layer,0);
 
-    m_game_layer->addChild(m_player->getSprite(),
-                                          INT_MAX);  // Player always on top
+    m_map_manager->addPlayer(m_player);
     m_player->setPosition(Point(WINDOW_WIDTH/2, WINDOW_HEIGHT/2));
 
     m_map_items.push_back(new Food());
@@ -105,7 +106,7 @@ void MainScene::update(float delta) {
     // Lookahead variable stores result of movement to be used in collision checks
     Point position_lookahead = m_player->getPosition();
 
-    Player::Direction dir = Player::DIR_DOWN;
+    Direction dir = Direction::DIR_DOWN;
     if (isKeyPressed(EventKeyboard::KeyCode::KEY_LEFT_SHIFT)) {
         if (m_player->getStamina() > 0) {
             delta *= 2;
@@ -118,7 +119,7 @@ void MainScene::update(float delta) {
     if(isKeyPressed(EventKeyboard::KeyCode::KEY_LEFT_ARROW) ||
        isKeyPressed(EventKeyboard::KeyCode::KEY_A)) {
         position_lookahead += Point(-(MOVE_STEP*delta), 0);
-        dir = Player::DIR_LEFT;
+        dir = Direction::DIR_LEFT;
         // Check if the movement results in collision. If so, undo the movement
         if(m_map_manager->checkCollision(position_lookahead)) {
             position_lookahead -= Point(-(MOVE_STEP*delta), 0);
@@ -130,7 +131,7 @@ void MainScene::update(float delta) {
         if(m_map_manager->checkCollision(position_lookahead)) {
             position_lookahead -= Point(+(MOVE_STEP*delta), 0);
         }
-        dir = Player::DIR_RIGHT;
+        dir = Direction::DIR_RIGHT;
     }
     if(isKeyPressed(EventKeyboard::KeyCode::KEY_UP_ARROW) ||
        isKeyPressed(EventKeyboard::KeyCode::KEY_W)) {
@@ -138,7 +139,7 @@ void MainScene::update(float delta) {
         if(m_map_manager->checkCollision(position_lookahead)) {
             position_lookahead -= Point(0, MOVE_STEP*delta);
         }
-        dir = Player::DIR_UP;
+        dir = Direction::DIR_UP;
     }
     if (isKeyPressed(EventKeyboard::KeyCode::KEY_DOWN_ARROW) ||
         isKeyPressed(EventKeyboard::KeyCode::KEY_S)) {
@@ -146,7 +147,7 @@ void MainScene::update(float delta) {
         if (m_map_manager->checkCollision(position_lookahead)) {
             position_lookahead -= Point(0, -(MOVE_STEP * delta));
         }
-        dir = Player::DIR_DOWN;
+        dir = Direction::DIR_DOWN;
     }
     if (isKeyPressed(EventKeyboard::KeyCode::KEY_Z)) {
         for (auto it : m_map_items) {
@@ -182,6 +183,9 @@ void MainScene::update(float delta) {
     m_player->updateHunger(-0.005);
     m_hud->update();
     m_player->setPosition(position_lookahead, dir);
+
+    // Set player's z order based on player sprite's lower edge
+    m_player->setZOrder(-(m_player->getPosition().y-PLAYER_SPRITE_HEIGHT/2));
 }
 
 // Because cocos2d-x requres createScene to be static, we need to make other

--- a/Live/Classes/MapManager.cpp
+++ b/Live/Classes/MapManager.cpp
@@ -5,6 +5,7 @@ USING_NS_CC;
 // Half the length of the player square's side
 // Needed to form the player hitbox, since the player is defined by a center position
 #define PLAYER_HALF_SIZE 12
+#define RESOURCE_LAYER_Z_ORDER 2       // Needs to be >1 for now due to foreground layer on demo map
 
 // Default constructor
 MapManager::MapManager() {
@@ -12,14 +13,24 @@ MapManager::MapManager() {
     m_collision_layer = m_tile_map->getLayer("Meta");
     m_map_width = m_tile_map->getMapSize().width * m_tile_map->getTileSize().width;
     m_map_height = m_tile_map->getMapSize().height * m_tile_map->getTileSize().height;
+    m_resources = new ResourceLayer();
+    m_tile_map->addChild(m_resources, RESOURCE_LAYER_Z_ORDER);
 }
 
 // Return reference to tile map so that it can be added to scene
 TMXTiledMap* MapManager::getTileMap() { return m_tile_map; }
 
+void MapManager::addPlayer(Player* player) {
+    m_resources->addChild(player->getSprite());
+}
+
 // Checks if a pixel coordinate lies on a collision tile
 bool MapManager::checkCollision(Point position) {
     // TODO: Implement using Rect
+    
+    if(m_resources->checkCollision(position)) {
+        return true;
+    }
 
     // Create a hitbox using 4 corners around the position
     Point* hitbox[4];

--- a/Live/Classes/MapManager.h
+++ b/Live/Classes/MapManager.h
@@ -2,7 +2,9 @@
 #define __MAP_MANAGER_H__
 
 #include "cocos2d.h"
+#include "ResourceLayer.h"
 #include <map>
+#include "Player.h"
 
 #define MAP_FILE_NAME "sample_map.tmx"
 #define COLLISION_LAYER_NAME "Meta"
@@ -15,11 +17,13 @@ public:
     bool checkCollision(cocos2d::Point position);
     bool checkCollision(cocos2d::Point position, float x, float y);
     cocos2d::TMXTiledMap* getTileMap();
+    void addPlayer(Player* player);
 
 private:
     cocos2d::TMXTiledMap *m_tile_map;
     cocos2d::TMXLayer *m_collision_layer;
     cocos2d::Point tileCoordForPosition(cocos2d::Point);
+    ResourceLayer *m_resources;
     float m_map_width; 
     float m_map_height; 
 };

--- a/Live/Classes/Player.cpp
+++ b/Live/Classes/Player.cpp
@@ -6,6 +6,9 @@
 
 USING_NS_CC;
 
+#define PLAYER_HITBOX_WIDTH 4
+#define PLAYER_HITBOX_HEIGHT 12
+
 Player::Player(const std::string& sprite_frame_file, unsigned int index) :
     m_hunger(DEFAULT_MAX_HUNGER),
     m_stamina(DEFAULT_MAX_STAMINA),
@@ -99,4 +102,8 @@ void Player::stopMove() {
     m_state = STANDING;
     m_sprite->stopAllActions();
     m_sprite->setDisplayFrame(m_anim_map[m_orientation].at(STATIONARY_INDEX));
+}
+
+Rect Player::getHitbox() {
+    return Rect(getPosition().x-PLAYER_HITBOX_WIDTH/2,getPosition().y-PLAYER_HITBOX_HEIGHT/2, PLAYER_HITBOX_WIDTH, PLAYER_HITBOX_HEIGHT);
 }

--- a/Live/Classes/Player.h
+++ b/Live/Classes/Player.h
@@ -4,6 +4,7 @@
 #include "cocos2d.h"
 #include "Item.h"
 #include "Inventory.h"
+#include "Direction.h"
 
 #define MAX_PICKUP_DISTANCE 40
 
@@ -19,25 +20,18 @@
 #define DEFAULT_MAX_HUNGER 100
 #define DEFAULT_MAX_STAMINA 100
 
+#define PLAYER_SPRITE_HEIGHT 48
+#define PLAYER_SPRITE_WIDTH 16
 
 class Player : public GameObject {
 public:
-    // Define all the different directions
-    typedef enum {
-        DIR_DOWN,
-        DIR_LEFT,
-        DIR_RIGHT,
-        DIR_UP,
-
-        NUM_DIR
-    } Direction;
     // Takes in the plist file and the initial sprite frame file index
     Player(const std::string& sprite_frame_file, unsigned int index);
     void updateHunger(float difference);
     void updateStamina(float difference);
     void moveX(float x);
     void moveY(float y);
-    void setPosition(cocos2d::Point point, Direction dir = DIR_DOWN);
+    void setPosition(cocos2d::Point point, Direction dir = Direction::DIR_DOWN);
     void move(float x, float y);
     void stopMove();
     float getHunger() const;
@@ -46,6 +40,7 @@ public:
     Item* drop(int i);
     bool use(int i);
     Inventory* get_inventory();
+    virtual cocos2d::Rect getHitbox();
 
 private:
     float m_hunger;

--- a/Live/Classes/ResourceLayer.cpp
+++ b/Live/Classes/ResourceLayer.cpp
@@ -1,0 +1,65 @@
+#include "ResourceLayer.h"
+#include <ctime>
+#include <cstdlib>
+
+USING_NS_CC;
+
+#define MAP_WIDTH 12500
+#define MAP_HEIGHT 8600
+
+ResourceLayer::ResourceLayer() : Layer() {
+    srand ( time(NULL) );
+
+    // Note that resources can be generated on top of each other no issue, 
+    //      just watch out for collisions with map file's collision layer
+    for(int i = 0; i < MAX_RESOURCES; i++) {
+        // TODO: Implement collision detection with main map during generation
+        //  Randomly generate resource locations based on demo map
+        //  Currently hardcoded to ensure no collision with water or beach areas
+        int r = rand() % MAP_WIDTH;
+        float x = r/10;
+        r = rand() % MAP_HEIGHT;
+        float y = r/10;
+
+        //This is a hack to avoid the pond on the bottom right of the demo map
+        //  as well as the player spawn location
+        while((x >= 1050 && y <= 380) || (std::abs(x-512)<50 && std::abs(y-364) < 50)) {
+            r = rand() % MAP_WIDTH;
+            x = r/10;
+            r = rand() % MAP_HEIGHT;
+            y = r/10;
+        }
+
+        //Choose between rock or tree
+
+        r = rand() % 8;
+        if(r == 1) {
+            m_resources[i] = new ResourceObstacle("Spritesheet/mapPack_spritesheet.png", 10*64, 3*64, x, y);
+        } else {
+            m_resources[i] = new ResourceObstacle(x,y);
+        }
+
+        this->addChild(m_resources[i]->getSprite());
+    }
+}
+
+bool ResourceLayer::checkCollision(cocos2d::Point position) {
+    // TODO: Replace point with rect, update MainScene.cpp to pass in a rect
+    Rect playerHitbox = Rect(position.x-2,position.y-24, 4, 12);
+    for(int i = 0; i < MAX_RESOURCES; i++) {
+        if(m_resources[i]->checkCollision(playerHitbox)) {
+            return true;
+        }
+    }
+    return false;
+}
+
+bool ResourceLayer::gather(cocos2d::Point position, Direction dir) {
+    for(int i = 0; i < MAX_RESOURCES; i++) {
+        if(m_resources[i]->gather(position, dir)) {
+            return true;
+        }
+    }
+    return false;
+}
+

--- a/Live/Classes/ResourceLayer.h
+++ b/Live/Classes/ResourceLayer.h
@@ -1,0 +1,23 @@
+#ifndef __RESOURCE_LAYER_H__
+#define __RESOURCE_LAYER_H__
+
+#include "cocos2d.h"
+#include <map>
+#include <stdlib.h> 
+#include "ResourceObstacle.h"
+
+#define MAX_RESOURCES 75
+
+class ResourceLayer : public cocos2d::Layer
+{
+public:
+    ResourceLayer();
+    bool checkCollision(cocos2d::Point position);
+    bool gather(cocos2d::Point position, Direction);	// Attempt to gather a resource from a resource obstacle you are facing
+
+private:
+    ResourceObstacle* m_resources[MAX_RESOURCES];
+};
+
+
+#endif // __RESOURCE_LAYER_H__

--- a/Live/Classes/ResourceObstacle.cpp
+++ b/Live/Classes/ResourceObstacle.cpp
@@ -1,0 +1,50 @@
+#include "ResourceObstacle.h"
+
+USING_NS_CC;
+
+#define TREE_WIDTH 64
+#define TREE_HEIGHT 64
+
+ResourceObstacle::ResourceObstacle(const std::string spritesheet, int spritesheet_x, int spritesheet_y, float posX, float posY) 
+	: RigidGameObject(spritesheet, spritesheet_x, spritesheet_y), m_resource_count(3)
+{
+	newSprite(TREE_WIDTH, TREE_HEIGHT);
+    setPosition(posX, posY);
+    m_hitbox = Rect(posX-(TREE_WIDTH/2),posY-(TREE_HEIGHT/2), TREE_WIDTH, TREE_HEIGHT/2);		// Set hitbox to lower half of sprite
+
+    // Set Z-order based on bottom of sprite, so that
+    //    obstacles lower on the y-axis are rendered in front of obstacles above it, enabling overlap
+    setZOrder(-(posY-(TREE_HEIGHT/2)));
+}
+
+ResourceObstacle::ResourceObstacle(float x, float y) 
+	: ResourceObstacle("Spritesheet/mapPack_spritesheet.png", 5*64, 7*64, x, y)
+{}
+
+// Gather resource, given that you are facing the obstacle
+bool ResourceObstacle::gather(cocos2d::Point pt, Direction dir) {
+
+	// Create a point in front of the player
+	Point ray = pt;
+
+	if(m_resource_count <= 0) {
+		return false;
+	}
+
+	if(dir == DIR_LEFT) {
+		ray += Point(-6, 0);
+	} else if(dir == DIR_RIGHT) {
+		ray += Point(6, 0);
+	} else if(dir == DIR_DOWN) {
+		ray += Point(0, -6);
+	} else if(dir == DIR_UP) {
+		ray += Point(0, 6);
+	}
+
+	if(m_hitbox.containsPoint(ray)) {
+		m_resource_count -= 1;
+		//Change sprite
+		return true;
+	}
+	return false;
+}

--- a/Live/Classes/ResourceObstacle.h
+++ b/Live/Classes/ResourceObstacle.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#include "GameObject.h"
+#include "Direction.h"
+#include "RigidGameObject.h"
+
+class ResourceObstacle : public RigidGameObject {
+public:
+	ResourceObstacle(const std::string spritesheet, int spritesheet_x, int spritesheet_y, float posX, float posY);
+    ResourceObstacle(float x, float y);
+    bool gather(cocos2d::Point, Direction);		// Gather a resource from an obstacle you are facing
+private:
+	int m_resource_count;
+};

--- a/Live/Classes/RigidGameObject.cpp
+++ b/Live/Classes/RigidGameObject.cpp
@@ -1,0 +1,23 @@
+#include "RigidGameObject.h"
+
+USING_NS_CC;
+
+RigidGameObject::RigidGameObject(const std::string sprite_file, unsigned int grid_pos_x,
+               unsigned int grid_pos_y) : GameObject(sprite_file, grid_pos_x, grid_pos_y) {
+	m_hitbox = Rect(0,0,0,0);
+}
+
+void RigidGameObject::setHitbox(int x, int y, int width, int length) {
+	m_hitbox = Rect(x,y,length,width);
+}
+
+ cocos2d::Rect RigidGameObject::getHitbox() {
+ 	return m_hitbox;
+ }
+
+bool RigidGameObject::checkCollision(cocos2d::Rect &hitbox) {
+	if(m_hitbox.intersectsRect(hitbox)) {
+		return true;
+	}
+	return false;
+}

--- a/Live/Classes/RigidGameObject.h
+++ b/Live/Classes/RigidGameObject.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include "GameObject.h"
+
+// Obstacles are game objects with hitboxes
+class RigidGameObject : public GameObject {
+public:
+    RigidGameObject(const std::string sprite_file, unsigned int grid_pos_x,
+               unsigned int grid_pos_y);
+    
+    void setHitbox(int x, int y, int width, int length);
+    virtual cocos2d::Rect getHitbox();
+
+    bool checkCollision(cocos2d::Rect&);
+protected:
+	cocos2d::Rect m_hitbox;
+};

--- a/Live/Resources/sample_map.tmx
+++ b/Live/Resources/sample_map.tmx
@@ -8,7 +8,7 @@
  </layer>
  <layer name="Meta" width="40" height="40">
   <data encoding="base64" compression="zlib">
-   eJztWF1OwzAMTo9BT7GX7g5sXIOD8LcLwDuCC8AF4B7wlh1ib60wopY84yR2kladtE+ymmbu5+9z+gPxzrk9hBeOnpz3EMN4lOaGQL4n44vGubb5O9JxH6gv1ZB0cG78jc614zzX0pNxB7Eej3SMnEPAH9WLXNQ350Y+OrdmfaFzOA6ha479UO9Sv9bMN+fmfNivTtCS0sbzuHdp3VB/jJtfH8v1aXn/vEv3BGqk+rW+W0WuRaNUn2u38Gm81EBI+xnLx3PFNdsFuK4D8wcF5w1cewtxB3EPsY3oXZHfJF+rwLW8xiXEBuIqszcbwoHHLeOTfOXWO2PZeIR1fVKsrTbPmpvCG/C8K7i0edZc9FLiycJhrYdeLJ5yOFCPth73UeOeiHGhHm097kPyY302NL2xrFfKyxTPhgWSlw+Iz/qlquEL4jvzWmkdtHNTgt9/FPy5oHMWbu15TFcsN6RJ+xzz81hPcnK19VOac2rR3Br3lqYnU3AvEaf8vvLueO9sX1jrAWJXyIH4/Z+b7gXhuAQvEK+lwkZgv/j+4FxI9Zrv9829h5HqtbRfJ/Uv9b6a6lup3a9Lva80364YUu8XvgdsQe43naLk76EUTu1bMAd+AGPH9Gc=
+   eJztWNsNgzAMDGOUKfiBHQpdo4P0oa7R2dIh+geqpWLJvdoQEFKjyidZMSa53Bm+HEMID4qorFE89xTDuGq1wdgfRb4rQiiL9yrz3rhfu0PTgdz8TtbKsY5aepHXFM24ypw5B8Of1Mtc0jdyM5+sNdAXWePcQl18+pHetX414Bu5kY/7VSta5rThPvSufTfWP8WN56f2xnl5X961f4I1Sv2pvsuEvUs0avej9iV8KV62gKXdkT/uG36zm8F1NOrPBM4TnT1TXCiuFN2E3kq803xVxlm8Y0/RUhxW9qYVHLx2wKf5Wnufw+FwOBwOh8Ph2AZyFsR5LqhhFsR5LuB+4XwwF+C8L7cZhjavy6l/S+Z1vwTOgB3/jRcgY34n
   </data>
  </layer>
  <layer name="Tile Layer 3" width="40" height="40">


### PR DESCRIPTION
- Added resourcelayer to the map manager, which manages resource obstacles drawn on top of the main map
- Added Obstacle class, which extends GameObject with a hitbox
- Added ResourceObstacle, which extends Obstacle with a resource counter and gather method
- Simulate player walking behind obstacle by changing ZOrder as player moves along y axis, and associating obstacles with a ZOrder based on their position on y axis